### PR TITLE
2.0.0: New major version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ update-pip:
 
 .PHONY: test-vault
 test-vault:
-	pytest --tb=short --junitxml ./logs/test-vault-report.xml -vvv --full-trace -p no:cacheprovider --html=./logs/test-vault-report.html --self-contained-html tests/test_vault.py tests/test_large_scale_vault.py
+	pytest --tb=short --junitxml ./logs/test-vault-report.xml -vvv --full-trace -p no:cacheprovider --html=./logs/test-vault-report.html --self-contained-html tests/test_vault.py tests/test_large_scale_vault.py tests/test_xml_vault.py

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ class Keyring(varvault.Keyring):
     arg2 = varvault.Key("arg2")
 
 
-vault = varvault.create_vault(Keyring, "example-vault", "~/.vault/vault.json", varvault.VaultFlags.return_values_cannot_be_none()))
+vault = varvault.create_vault(Keyring, "example-vault", varvault.VaultFlags.return_values_cannot_be_none(), varvault_vault_filename_to="~/.vault/vault.json", varvault_filehandler_class=varvault.FileTypes.JSON))
 
 
 @vault.vaulter(return_keys=[Keyring.arg1, Keyring.arg2])
@@ -68,9 +68,11 @@ if __name__ == "__main__":
    Optionally, you can define some flags to further tweak the behavior of the vault. These tweaked behaviors include
    allowing for existing key-value pairs to be modified (this is not allowed by default), allowing return variables from
    functions defined with return keys to be None, and setting a flag to write some additional debug logs.
-   You can also define a .JSON file to be used as a vault file to store all the arguments in.
+   You can also define a .JSON file to be used as a vault file to store all the arguments in. 
+   In this example, we use the provided file-handler `JsonFileHandler` (which is assigned to `varvault.FileTypes.JSON` internally), 
+   but it's also possible to provide a custom file-handler object if you want to create your own file type.  
 
-3. We create a function called `create_args` that takes some arguments (we have to insert variables
+4. We create a function called `create_args` that takes some arguments (we have to insert variables
    into the vault somehow, right?) that we annotate with the vault decorator. We pass an argument to the
    decorator called `return_keys`. This argument tells the vault which keys this function will assign its
    return variables to. Note that the order of the return keys matter. In this case, the ingoing argument `arg1` will
@@ -83,7 +85,7 @@ if __name__ == "__main__":
    those return variables in the vault with the keys that were passed to the decorator. These variables can then be 
    accessed by another function that uses the same vault-object as this one does.
 
-4. We then create a new function called `use_args` that we also annotate with the vault decorator. We pass a different
+5. We then create a new function called `use_args` that we also annotate with the vault decorator. We pass a different
    argument to the decorator this time called `input_keys`. This argument tells the vault which keys in the vault
    we want passed to this function. The order of the keys doesn't really matter here, the order is mostly aesthetic.
    
@@ -96,16 +98,16 @@ if __name__ == "__main__":
    a default value, like None. Otherwise, when you call the function, you have to call the function with the arguments
    fulfilled as well.
 
-5. We create a very simple function called `run_create_args` which doesn't get annotated. This function is simply made
+6. We create a very simple function called `run_create_args` which doesn't get annotated. This function is simply made
    to demonstrate what makes this vault so useful. When this function is called, it will obviously call `create_args`,
    which will create  Keyring.arg1` and `Keyring.arg2` which will then be stored in the vault.
 
-6. A final function called `run_use_args` is then created which calls the `use_args` function. This function
+7. A final function called `run_use_args` is then created which calls the `use_args` function. This function
    is able to use the arguments defined in `create_args` because with this vault, the context for where a function runs
    doesn't really matter as long as the input variables it needs exists in the vault-object already, and the function
    exists in that scope.
 
-7. Lastly, the variables that were involved in the execution of this code can be viewed by simply checking the contents 
+8. Lastly, the variables that were involved in the execution of this code can be viewed by simply checking the contents 
    of the file `~/.vault/vault.json`. In this example the file would simply contain: 
    ```
    {
@@ -113,12 +115,13 @@ if __name__ == "__main__":
      "arg2": 2
    }
    ```
-8. When a file such as this (see above) exists, it's very possible to re-create the same vault again from this file. 
+9. When a file such as this (see above) exists, it's very possible to re-create the same vault again from this file. 
    In order to re-create the same vault again simply do this: 
    ```
    vault = varvault.from_vault_file(Keyring,
                                     "example-vault",
                                     "~/.vault/vault.json",
+                                    varvault.FileTypes.JSON,
                                     varvault.VaultFlags.permit_modifications()))
    ```
    When re-creating a vault from an existing file it's recommended to allow modifications 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ setuptools
 wheel
 build
 twine
+xmltodict
 pytest>=6.2.1
 pytest-html>=2.1.1
 pytest-metadata>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ README = pathlib.Path(f"{HERE}/README.md").read_text()
 
 # Version handling
 # A good way to tell if we are backwards compatible is to run the test suite and if the tests pass without requiring any changes, we can pretty safely assume we are backwards compatible.
-MAJOR = 1  # Change this if the previous MAJOR is incompatible with this build. Set MINOR and PATCH to 0
-MINOR = 3  # Change this if the functionality has changed, but we are still backwards compatible with previous MINOR versions. Set PATCH to 0
+MAJOR = 2  # Change this if the previous MAJOR is incompatible with this build. Set MINOR and PATCH to 0
+MINOR = 0  # Change this if the functionality has changed, but we are still backwards compatible with previous MINOR versions. Set PATCH to 0
 PATCH = 0  # Change this is if we are fixing a bug that doesn't change the functionality. If a bug-fix has caused functionality to be changed, see MINOR instead
 VERSION = f"{MAJOR}.{MINOR}.{PATCH}"
 
@@ -31,7 +31,7 @@ def find_todos_for_version_in_code():
     # fix me: Remove this in 2.0.0
     # to do: Remove this in 2.0.0
     """
-    pattern = re.compile(rf".*(\#.*(?:[Ff][Ii][Xx].*[Mm][Ee]|[Tt][Oo].*[Dd][Oo]).*{MAJOR}\.{MINOR}\.{PATCH}.*)")
+    pattern = re.compile(rf".*(#.*(?:[Ff][Ii][Xx].*[Mm][Ee]|[Tt][Oo].*[Dd][Oo]).*{MAJOR}\.{MINOR}\.{PATCH}.*)")
     files = glob.glob("varvault/*.py")
     matches = list()
     for file in files:

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,4 @@
 new-vault.json
 new-vault-secondary.json
+
+new-vault.xml

--- a/tests/existing-vault.xml
+++ b/tests/existing-vault.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VAULT>
+    <string_value>valid</string_value>
+    <int_value>1</int_value>
+</VAULT>

--- a/tests/test_large_scale_vault.py
+++ b/tests/test_large_scale_vault.py
@@ -3,8 +3,8 @@ import os
 import sys
 import time
 
-import pytest
 import logging
+
 DIR = os.path.dirname(os.path.realpath(__file__))
 path = f"{os.path.dirname(DIR)}"
 temp_path = [path]
@@ -128,8 +128,14 @@ class KeyringLargeScale(varvault.Keyring):
 
 class TestLargeScaleVault:
 
+    def setup_method(self):
+        try:
+            os.remove(vault_file_new)
+        except:
+            pass
+
     def test_load_from_large_vault(self):
-        vault = varvault.from_vault(KeyringLargeScale, "vault", large_vault_file, varvault.VaultFlags.remove_existing_log_file(), varvault.VaultFlags.remove_existing_log_file(), varvault_vault_filename_to=vault_file_new)
+        vault = varvault.from_vault(KeyringLargeScale, "vault", large_vault_file, varvault.FileTypes.JSON, varvault.VaultFlags.remove_existing_log_file(), varvault.VaultFlags.remove_existing_log_file(), varvault_vault_filename_to=vault_file_new)
         logger.info("Created the vault from file")
         # We load from existing and write to new, so just check that the new file contains the correct data
         contents = json.load(open(vault_file_new))
@@ -181,7 +187,7 @@ class TestLargeScaleVault:
         assert KeyringLargeScale.result in contents
 
     def test_get_multiple(self):
-        vault = varvault.from_vault(KeyringLargeScale, "vault", large_vault_file, varvault.VaultFlags.remove_existing_log_file(), varvault_vault_filename_to=vault_file_new)
+        vault = varvault.from_vault(KeyringLargeScale, "vault", large_vault_file, varvault.FileTypes.JSON, varvault.VaultFlags.remove_existing_log_file(), varvault_vault_filename_to=vault_file_new)
         keys = [KeyringLargeScale.workspace_dir,
                 KeyringLargeScale.test_time,
                 KeyringLargeScale.start_time,
@@ -200,7 +206,7 @@ class TestLargeScaleVault:
         assert len([key for key in keys if key not in vars]) == 0, f"Keys are missing in vars: {[key for key in keys if key not in vars]}"
 
     def test_get_via_vaulter(self):
-        vault = varvault.from_vault(KeyringLargeScale, "vault", large_vault_file, varvault.VaultFlags.remove_existing_log_file(), varvault_vault_filename_to=vault_file_new)
+        vault = varvault.from_vault(KeyringLargeScale, "vault", large_vault_file, varvault.FileTypes.JSON, varvault.VaultFlags.remove_existing_log_file(), varvault_vault_filename_to=vault_file_new)
         keys = [KeyringLargeScale.workspace_dir,
                 KeyringLargeScale.test_time,
                 KeyringLargeScale.cpus_per_container,
@@ -257,7 +263,7 @@ class TestLargeScaleVault:
     def test_get_threaded(self):
         # Note the use of varvault.VaultFlags.silent() here. It will speed up the processing significantly.
         # It brings processing down from 1.6 seconds to 0.16 seconds for 500 parallel requests.
-        vault = varvault.from_vault(KeyringLargeScale, "vault", large_vault_file, varvault.VaultFlags.silent(), varvault.VaultFlags.remove_existing_log_file(), varvault_vault_filename_to=vault_file_new)
+        vault = varvault.from_vault(KeyringLargeScale, "vault", large_vault_file, varvault.FileTypes.JSON, varvault.VaultFlags.silent(), varvault.VaultFlags.remove_existing_log_file(), varvault_vault_filename_to=vault_file_new)
         keys = [KeyringLargeScale.workspace_dir,
                 KeyringLargeScale.test_time,
                 KeyringLargeScale.cpus_per_container,
@@ -325,7 +331,7 @@ class TestLargeScaleVault:
             # It's fine, file probably doesn't exist
             pass
 
-        vault = varvault.from_vault(KeyringLargeScale, "vault", vault_file_new, varvault.VaultFlags.live_update(), varvault.VaultFlags.remove_existing_log_file())
+        vault = varvault.from_vault(KeyringLargeScale, "vault", vault_file_new, varvault.FileTypes.JSON, varvault.VaultFlags.live_update(), varvault.VaultFlags.remove_existing_log_file())
 
         keys = [KeyringLargeScale.workspace_dir,
                 KeyringLargeScale.test_time,

--- a/tests/test_xml_vault.py
+++ b/tests/test_xml_vault.py
@@ -1,0 +1,84 @@
+import os
+from typing import Union, Dict, List
+
+import sys
+import logging
+import tempfile
+import xmltodict
+
+import varvault
+from varvault import BaseFileHandler
+
+
+DIR = os.path.dirname(os.path.realpath(__file__))
+path = f"{os.path.dirname(DIR)}"
+temp_path = [path]
+temp_path.extend(sys.path)
+sys.path = temp_path
+
+logger = logging.getLogger("pytest")
+vault_file_new = f"{DIR}/new-vault.xml"
+existing_vault = f"{DIR}/existing-vault.xml"
+
+
+class XmlFileHandler(BaseFileHandler):
+    KEY = "VAULT"
+
+    def __init__(self, filename: str, live_update=False, file_is_read_only=False):
+        super(XmlFileHandler, self).__init__(filename, live_update, file_is_read_only)
+
+    def do_write(self, vault: dict):
+        # An XML file must have exactly one root. We assign the vault to the root self.KEY
+        vault = {self.KEY: vault}
+        xmltodict.unparse(vault, open(self.file.name, "w"), pretty=True)
+
+    def do_read(self) -> Union[Dict, List]:
+        vault = xmltodict.parse(open(self.file.name, "rb"))
+        return vault[self.KEY]
+
+
+class Keyring(varvault.Keyring):
+    string_value = varvault.Key("string_value")
+    int_value = varvault.Key("int_value")
+    list_value = varvault.Key("list_value")
+
+
+class TestXmlVault:
+    @classmethod
+    def setup_class(cls):
+        logger.info(tempfile.tempdir)
+        tempfile.tempdir = "/tmp" if sys.platform == "darwin" or sys.platform == "linux" else tempfile.gettempdir()
+        logger.info(tempfile.tempdir)
+
+    def setup_method(self):
+        try:
+            os.remove(vault_file_new)
+        except:
+            pass
+
+    def test_create_xml_vault(self):
+        vault = varvault.create_vault(Keyring, "vault", varvault_vault_filename_to=vault_file_new, varvault_filehandler_class=XmlFileHandler)
+
+        @vault.vaulter(return_keys=(Keyring.string_value, Keyring.int_value, Keyring.list_value))
+        def _set():
+            return "valid", 1, [1, 2, 3, 4, 5]
+
+        _set()
+
+        data_in_file = xmltodict.parse(open(vault_file_new, "rb"))[XmlFileHandler.KEY]
+        logger.info(data_in_file)
+        assert Keyring.string_value in data_in_file and data_in_file[Keyring.string_value] == "valid"
+        # XML data is actually just strings. But we still want to support using XML files, but it will take some manual labour to get it working correctly.
+        assert Keyring.int_value in data_in_file and data_in_file[Keyring.int_value] == "1"
+        assert Keyring.list_value in data_in_file
+
+    def test_read_from_xml_vault(self):
+        vault = varvault.from_vault(Keyring, "vault-from", existing_vault, XmlFileHandler, varvault.VaultFlags.file_is_read_only())
+
+        @vault.vaulter(input_keys=(Keyring.string_value, Keyring.int_value))
+        def _get(string_value=None, int_value=None):
+            assert string_value == "valid"
+            assert int_value == "1"
+
+        _get()
+

--- a/varvault/__init__.py
+++ b/varvault/__init__.py
@@ -1,10 +1,12 @@
+from .filehandlers import JsonFilehandler
+
 from .keyring import Key, Keyring, validator
 
 from .minivault import MiniVault
 
 from .utils import *
 
-from .vault import VarVault
+from .vault import VarVault, VarVaultInterface
 
 from .vaultflags import VaultFlags
 
@@ -14,10 +16,16 @@ from .vaultfactory import from_vault
 from .vaultstructs import *
 
 
+class FileTypes:
+    JSON: Type[JsonFilehandler] = JsonFilehandler
+
+
 def clear_logs():
     import os
     import glob
+    import tempfile
 
-    files = glob.glob("/tmp/varvault-logs/*.log")
+    path = os.path.join(tempfile.tempdir, "varvault-logs", "*.log")
+    files = glob.glob(path)
     for f in files:
         os.remove(f)

--- a/varvault/filehandlers.py
+++ b/varvault/filehandlers.py
@@ -1,0 +1,100 @@
+import abc
+import json
+import os.path
+import threading
+import warnings
+
+from typing import Union, Dict, List, TextIO
+
+
+class BaseFileHandler(abc.ABC):
+    def __init__(self, filename: str, live_update=False, file_is_read_only=False):
+        self.lock = threading.Lock()
+        self.raw_filename = filename
+        self.live_update = live_update
+        self.file_is_read_only = file_is_read_only
+        self.file = filename
+
+    @property
+    def file(self) -> TextIO:
+        return self.file_io
+
+    @file.setter
+    def file(self, filename: str):
+
+        if filename and self.live_update and not os.path.exists(filename):
+            self.file_io = None
+            raise FileNotFoundError("Unable to find the file and live-update is defined. This is fine, but we need to raise the error and handle it.")
+        elif filename and not os.path.exists(filename):
+            # Create the file; It doesn't exist
+            self.file_io = open(filename, "w")
+            self.file_io.close()
+        elif filename and os.path.exists(filename):
+            # The file already exists; Just read from it
+            self.file_io = open(filename)
+            self.file_io.close()
+        else:
+            raise NotImplementedError("This is not supported")
+
+    # ================================================================================================================
+    # Write
+    # ================================================================================================================
+    def write(self, vault: dict):
+        if self.file_is_read_only:
+            warnings.warn("Tried to write to a vault-file defined as read-only. This is not permitted by varvault.")
+        if self.file:
+            with self.lock:
+                self.do_write(vault)
+
+    @abc.abstractmethod
+    def do_write(self, vault: dict):
+        """
+        A function to write data to a file. Varvault will call this function internally.
+        The class that implements this abstractmethod has to write a dict to a file and then close the file.
+
+        Example:
+        `json.dump(vault, open(self.file.name, "w"), indent=2)`
+
+        :param vault: The vault to write to the file.
+        :return: None. Varvault will not use the return value from this function
+        """
+        pass
+
+    # ================================================================================================================
+    # Read
+    # ================================================================================================================
+    def read(self) -> Dict:
+        if self.file:
+            with self.lock:
+                try:
+                    return self.do_read()
+                except Exception as e:
+                    if self.live_update:
+                        # live-update has been defined; This means that any error from reading
+                        # the file must be considered okay as the file might not exist yet.
+                        return {}
+                    raise e
+
+    @abc.abstractmethod
+    def do_read(self) -> Dict:
+        """
+        A function to read data from a file. Varvault will call this function internally.
+        The class that implements this abstractmethod has to read data from a file and then return it.
+
+        Example:
+        `return json.load(open(self.file.name))`
+
+        :return: A dict describing the vault from the file.
+        """
+        pass
+
+
+class JsonFilehandler(BaseFileHandler):
+    def __init__(self, filename: str, live_update=False, file_is_read_only=False):
+        super(JsonFilehandler, self).__init__(filename, live_update, file_is_read_only)
+
+    def do_write(self, vault: dict):
+        json.dump(vault, open(self.file.name, "w"), indent=2)
+
+    def do_read(self) -> Union[Dict, List]:
+        return json.load(open(self.file.name))

--- a/varvault/logger.py
+++ b/varvault/logger.py
@@ -4,7 +4,7 @@ import tempfile
 
 
 def get_logger(name, remove_existing_log_file=False):
-    """Returns a logger for name that logs to a specific file."""
+    f"""Returns a logger for {name} that logs to a specific file."""
 
     class CustomFormat(logging.Formatter):
         FORMATS = {logging.INFO: logging.PercentStyle(f'%(levelname)s - %(asctime)s %(name)s - %(message)s'),
@@ -60,7 +60,7 @@ def get_logger(name, remove_existing_log_file=False):
 
 
 def configure_logger(logger: logging.Logger, overall_level=logging.DEBUG, stream_level=logging.INFO, file_level=logging.DEBUG):
-    """Configures a logger by setting the logging levels for the different handlers."""
+    f"""Configures a {logger} by setting the logging levels for the different handlers."""
     logger.setLevel(overall_level)
 
     for handler in logger.handlers:

--- a/varvault/minivault.py
+++ b/varvault/minivault.py
@@ -14,7 +14,7 @@ class MiniVault(dict):
 
     @staticmethod
     def build(keys: List[Key] or Tuple[Key], values: List[Any] or Tuple[Any]):
-        """Builds a minivault object based on iterables of keys and values. Note that if more values are passed to the function than keys,
+        f"""Builds a {MiniVault}-object based on iterables of {keys} and {values}. Note that if more values are passed to the function than keys,
         the indices for the values that exceed the length of the keys will be ignored."""
         assert isinstance(keys, (list, tuple)), "'keys' must be a list or a tuple"
         assert isinstance(values, (list, tuple)), "'values' must be a list or a tuple"

--- a/varvault/utils.py
+++ b/varvault/utils.py
@@ -8,6 +8,7 @@ from typing import *
 from .keyring import Keyring, Key
 from .minivault import MiniVault
 from .vaultstructs import VaultStructBase
+from .filehandlers import BaseFileHandler
 
 
 def md5hash(fname):
@@ -21,7 +22,6 @@ def md5hash(fname):
 
 def is_serializable(obj: object, logger: logging.Logger = None):
     f"""Function for testing whether or not an object can be serialized by simply trying to do {json.dumps} on the object. Returns {True} if {obj} can be serialized, otherwise {False}."""
-
     try:
         json.dumps(obj)
         return True
@@ -114,18 +114,17 @@ def concurrent_execution(target: Union[Coroutine, FunctionType, Callable], *inpu
     return asyncio.run(do(target, *inputs, **kwargs))
 
 
-def create_mini_vault_from_file(filename_from: str, keyring: Type[Keyring], **extra_keys) -> MiniVault:
-    """Creates a minivault object from a file by."""
-    import json
+def create_mini_vault_from_file(varvault_filename_from: str, varvault_keyring: Type[Keyring], varvault_filehandler_class: Type[BaseFileHandler], varvault_live_update=False, varvault_file_is_read_only=False, **extra_keys) -> MiniVault:
+    f"""Creates a {MiniVault}-object from a file by loading the vault from the file using the {varvault_filehandler_class} passed."""
 
-    assert issubclass(keyring, Keyring)
-    vault_file_data = dict()
+    assert issubclass(varvault_keyring, Keyring)
+    filehandler = varvault_filehandler_class(varvault_filename_from, varvault_live_update, varvault_file_is_read_only)
+    vault_file_data = filehandler.read()
 
-    vault_file_data = json.load(open(filename_from))
     assert isinstance(vault_file_data, dict)
 
     # Get the keys from the file as a list.
-    keys_from_keyring = keyring.get_keys_in_keyring()
+    keys_from_keyring = varvault_keyring.get_keys_in_keyring()
     keys_from_keyring.update(extra_keys)
     return_vault_data = dict()
 

--- a/varvault/vaultfactory.py
+++ b/varvault/vaultfactory.py
@@ -1,11 +1,11 @@
-import json
 import logging
 import os
 
 from typing import *
 
-from . import MiniVault
+from .filehandlers import BaseFileHandler, JsonFilehandler
 from .keyring import Keyring
+from .minivault import MiniVault
 from .vaultflags import VaultFlags
 from .vault import VarVault
 from .utils import create_mini_vault_from_file
@@ -15,6 +15,7 @@ def create_vault(varvault_keyring: Type[Keyring],
                  varvault_vault_name: str,
                  *flags: VaultFlags,
                  varvault_vault_filename_to: str = None,
+                 varvault_filehandler_class: Type[BaseFileHandler] = JsonFilehandler,
                  varvault_specific_logger: logging.Logger = None,
                  **extra_keys) -> VarVault:
     """
@@ -22,8 +23,8 @@ def create_vault(varvault_keyring: Type[Keyring],
 
     :param varvault_keyring: Describes which keys belong to this Vault.
     :param varvault_vault_name: Used to name the vault and the logger for writing information and debug messages.
-    :param varvault_vault_filename_to: Optional filename for a .JSON file to write the arguments in the vault to.
-    :param use_logger: Optional argument for telling varvault to use a logger or not. Default behavior is to use a logger object.
+    :param varvault_vault_filename_to: Optional filename for a file to write the arguments in the vault to.
+    :param varvault_filehandler_class: Optional argument to specify type of the file type used for the vault files.
     :param flags: Optional argument for defining VaultFlags for this Vault.
      Note that any global VaultFlag will be overridden by VaultFlags defined in a vault-decorator.
     :param varvault_specific_logger: Optional argument for defining your own logger object if you want to use a specific logger rather than varvault's own logger.
@@ -33,12 +34,18 @@ def create_vault(varvault_keyring: Type[Keyring],
     """
     if not VaultFlags.flag_is_set(VaultFlags.remove_existing_log_file(), *flags):
         flags = (VaultFlags.remove_existing_log_file(), *flags)
-    return VarVault(varvault_keyring, varvault_vault_name, *flags, varvault_vault_filename_from=varvault_vault_filename_to, varvault_vault_filename_to=varvault_vault_filename_to, varvault_specific_logger=varvault_specific_logger, **extra_keys)
+    return VarVault(varvault_keyring, varvault_vault_name, *flags,
+                    varvault_vault_filename_from=varvault_vault_filename_to,
+                    varvault_vault_filename_to=varvault_vault_filename_to,
+                    varvault_filehandler_class=varvault_filehandler_class,
+                    varvault_specific_logger=varvault_specific_logger,
+                    **extra_keys)
 
 
 def from_vault(varvault_keyring: Type[Keyring],
                varvault_vault_name: str,
                varvault_vault_filename_from: str,
+               varvault_filehandler_class: Type[BaseFileHandler],
                *flags: VaultFlags,
                varvault_vault_filename_to: str = None,
                varvault_specific_logger: logging.Logger = None,
@@ -48,7 +55,8 @@ def from_vault(varvault_keyring: Type[Keyring],
 
     :param varvault_keyring: Describes which keys belong to this Vault.
     :param varvault_vault_name: Used to name the vault and the logger for writing information and debug messages.
-    :param varvault_vault_filename_from: Filename for a .JSON file to load variables from.
+    :param varvault_vault_filename_from: Filename for a file to load variables from.
+    :param varvault_filehandler_class: The file type of the vault_filename_from.
     :param flags: A set of VaultFlags to tweak the behavior of the vault.
     :param varvault_vault_filename_to: Optional filename to write the variables to. This can be a separate file to the file we read from.
     :param varvault_specific_logger: Optional argument for defining your own logger object if you want to use a specific logger rather than varvault's own logger.
@@ -58,10 +66,11 @@ def from_vault(varvault_keyring: Type[Keyring],
     :return: A vault based on vault_filename_from and keyring.
     """
     varvault_vault_filename_from = os.path.expanduser(os.path.expandvars(varvault_vault_filename_from))
-    live_update = VaultFlags.flag_is_set(VaultFlags.live_update(), *flags)
+    varvault_live_update = VaultFlags.flag_is_set(VaultFlags.live_update(), *flags)
+    varvault_file_is_read_only = VaultFlags.flag_is_set(VaultFlags.file_is_read_only(), *flags)
     ignore_keys_not_in_keyring = VaultFlags.flag_is_set(VaultFlags.file_is_read_only(), *flags) or VaultFlags.flag_is_set(VaultFlags.ignore_keys_not_in_keyring(), *flags)
 
-    if not os.path.exists(varvault_vault_filename_from) and not live_update:
+    if not os.path.exists(varvault_vault_filename_from) and not varvault_live_update:
         raise FileNotFoundError(f"Vault-file {varvault_vault_filename_from} doesn't appear to exist, and you have not requested live-update via the flag {VaultFlags.live_update.__name__}.")
 
     if varvault_vault_filename_to:
@@ -71,7 +80,9 @@ def from_vault(varvault_keyring: Type[Keyring],
 
     def _check_for_keys_not_in_keyring():
         try:
-            vault_file_data = json.load(open(varvault_vault_filename_from))
+            vault_file_data = varvault_filehandler_class(filename=varvault_vault_filename_from,
+                                                         live_update=varvault_live_update,
+                                                         file_is_read_only=varvault_file_is_read_only).read()
         except FileNotFoundError:
             if VaultFlags.flag_is_set(VaultFlags.live_update(), *flags):
                 # No point checking for keys not in the keyring at this point
@@ -92,9 +103,9 @@ def from_vault(varvault_keyring: Type[Keyring],
         return _keys_not_in_keyring
     keys_not_in_keyring = _check_for_keys_not_in_keyring()
     try:
-        mini = create_mini_vault_from_file(varvault_vault_filename_from, varvault_keyring, **extra_keys)
+        mini = create_mini_vault_from_file(varvault_vault_filename_from, varvault_keyring, varvault_filehandler_class, varvault_live_update, varvault_file_is_read_only, **extra_keys)
     except FileNotFoundError:
-        if live_update:
+        if varvault_live_update:
             # This is fine; If live_update is defined, it must be possible for the file to not exist yet.
             mini = MiniVault()
         else:
@@ -103,6 +114,7 @@ def from_vault(varvault_keyring: Type[Keyring],
     vault = VarVault(varvault_keyring, varvault_vault_name, *flags,
                      varvault_vault_filename_from=varvault_vault_filename_from,
                      varvault_vault_filename_to=varvault_vault_filename_to,
+                     varvault_filehandler_class=varvault_filehandler_class,
                      varvault_specific_logger=varvault_specific_logger,
                      **extra_keys)
     vault.vault.put(mini)

--- a/varvault/vaultflags.py
+++ b/varvault/vaultflags.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import warnings
-
 
 class VaultFlags(str):
     """Class that represents flags that may be used for a vaulted
@@ -21,6 +19,7 @@ class VaultFlags(str):
     _IGNORE_KEYS_NOT_IN_KEYRING = "ignore_keys_not_in_keyring"
     _REMOVE_EXISTING_LOG_FILE = "remove_existing_log_file"
     _RETURN_KEY_CAN_BE_MISSING = "return_key_can_be_missing"
+    _NO_ERROR_LOGGING = "no_error_logging"
 
     def __new__(cls, name, *args, **kwargs):
         obj = super().__new__(cls, name)
@@ -51,30 +50,10 @@ class VaultFlags(str):
         By default, varvault doesn't permit modifications to existing keys as this can cause unintended behavior."""
         return VaultFlags(VaultFlags._PERMIT_MODIFICATIONS)
 
-    # FIXME: Remove this in 2.0.0
-    @staticmethod
-    def input_var_can_be_missing():
-        f"""Flag to set if an input variable may be missing in a vault when it is accessed. In this case, the key will be sent to kwargs but it will be mapped to {None}."""
-        warnings.warn(f"Using deprecated vault-flag {VaultFlags.input_var_can_be_missing.__name__}. "
-                      f"This function is deprecated and will be removed in 2.0.0. Please use {VaultFlags.input_key_can_be_missing.__name__} instead",
-                      category=DeprecationWarning)
-        return VaultFlags.input_key_can_be_missing()
-
     @staticmethod
     def input_key_can_be_missing():
         f"""Flag to set if an input variable may be missing in a vault when it is accessed. In this case, the key will be sent to kwargs but it will be mapped to {None}."""
         return VaultFlags(VaultFlags._INPUT_KEY_CAN_BE_MISSING)
-
-    # FIXME: Remove this in 2.0.0
-    @staticmethod
-    def clean_return_var_keys():
-        f"""Flag to clean return keys in a vault defined for a decorated function. This can be used during a cleanup stage. 
-        Varvault will try to map the key to a default value for the valid type, like for example str(), or list(). If it doesn't work, the key will be mapped to {None}."""
-        warnings.warn(f"Using deprecated vault-flag {VaultFlags.clean_return_var_keys.__name__}. "
-                      f"This function is deprecated and will be removed in 2.0.0. Please use {VaultFlags.clean_return_keys.__name__} instead",
-                      category=DeprecationWarning,
-                      stacklevel=2)
-        return VaultFlags.clean_return_keys()
 
     @staticmethod
     def clean_return_keys():
@@ -138,3 +117,9 @@ class VaultFlags(str):
         """Flag to tell varvault when using a vaulter-decorated function and not returning objects for all keys to not fail and just set the keys defined.
          If this is set, the return variables MUST be inside a MiniVault object, otherwise varvault cannot determine what variable belongs to what key."""
         return VaultFlags(VaultFlags._RETURN_KEY_CAN_BE_MISSING)
+
+    @staticmethod
+    def no_error_logging():
+        """Flag to tell a vaulter-decorated function to not log exceptions. Exceptions can sometimes be expected,
+        and sometimes it might be preferable to not log errors using varvault and just log them normally."""
+        return VaultFlags(VaultFlags._NO_ERROR_LOGGING)

--- a/varvault/vaultstructs.py
+++ b/varvault/vaultstructs.py
@@ -8,40 +8,24 @@ class VaultStructBase(abc.ABC):
         pass
 
 
-class VaultStructDictBase(VaultStructBase, dict):
-    @classmethod
-    @abc.abstractmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
-        pass
+class VaultStructDictBase(VaultStructBase, dict, abc.ABC):
 
     def __setattr__(self, key, value):
         super(VaultStructDictBase, self).__setattr__(key, value)
         super(VaultStructDictBase, self).__setitem__(key, value)
 
 
-class VaultStructListBase(VaultStructBase, list):
-    @classmethod
-    @abc.abstractmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
-        pass
+class VaultStructListBase(VaultStructBase, list, abc.ABC):
+    pass
 
 
-class VaultStructStringBase(VaultStructBase, str):
-    @classmethod
-    @abc.abstractmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
-        pass
+class VaultStructStringBase(VaultStructBase, str, abc.ABC):
+    pass
 
 
-class VaultStructIntBase(VaultStructBase, int):
-    @classmethod
-    @abc.abstractmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
-        pass
+class VaultStructIntBase(VaultStructBase, int, abc.ABC):
+    pass
 
 
-class VaultStructFloatBase(VaultStructBase, float):
-    @classmethod
-    @abc.abstractmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
-        pass
+class VaultStructFloatBase(VaultStructBase, float, abc.ABC):
+    pass


### PR DESCRIPTION
* Made changes to allow for the possibility to select a file-handler to write to the vault file, and to implement your own file-handler. If you want to use XML, you can create your own handler for doing that. You need to overload the read/write functions and make them read a dict from the file and write a dict to the file.
* Removed deprecated vault-flags that were marked for deletion in 2.0.0.
* Added some new vault-flags, such as a flag for disabling error logging.

This version is mostly compatible with 1.x but there are some differences that are noteworthy:
* The signature for `vaultfactory.from_vault()` has changed to become non-compatible with previous versions. The function enforces a positional argument for the file-handler class, which in most cases will be `varvault.FileTypes.JSON`. It could be defaulted, but that's not preferable as it becomes inconsistent.