### PR TITLE
4.0.0: New major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ if __name__ == "__main__":
    In order to re-create the same vault again simply do this: 
    ```python
    import varvault
-   
+
+   class Keyring(varvault.Keyring):
+       arg1 = varvault.Key("arg1")
+       arg2 = varvault.Key("arg2")
       
    vault = varvault.from_vault(Keyring,
                                "example-vault",
@@ -139,15 +142,26 @@ if __name__ == "__main__":
    (see `varvault.VaultFlags.permit_modifications`) in-case you are planning to write the same
    arguments to the vault again. 
 
-Conclusion. This flow demonstrates what this functionality can be used for. With this vault, the context for where
-a function executes doesn't matter as long as the keys the function needs have been assigned in the vault and the
+## Conclusion
+This README demonstrates what this functionality can be used for. With this vault, the context for where
+a function executes doesn't matter as long as the keys the function require have been assigned in the vault and the
 functions exists in the scope. The functions become building blocks that you can call regardless of context provided
 the above criteria have been met. You don't need to clutter your function calls with tons of input variables because
 all of that is handled for you by the vault and the decorator. If you use it correctly, you can end up with
 functions that on the surface appears to not use any arguments or pass any return variables at all. This makes the main
-body of your code clean and easy to follow. You can then use the Keyring to see where your keys are
-actually being used. By saving arguments to a file, it allows you to keep parts of the context the code ran 
-in previously. This can be very useful when deploying something which then has to be un-deployed at a later time that 
-isn't necessarily running in the same process as before. This adds an extra layer similar to environment variables 
-that works slightly differently and exclusively in Python. Since the arguments are saved to a JSON file, anything that
-can parse JSON can obviously use the data as they see fit. 
+body of your code clean and easy to follow. 
+
+By using this functionality, you can create a vault that can be used in any context, and you can use the vault to
+store variables that are used in multiple functions. This is very useful when you have a lot of functions that need to
+use the same variables at different depths of your code. 
+
+Adding new input variables or return variables to a function is very easy, because you don't need to think about how
+the function is used, as long as it is used in the correct context. Varvault handles all input variables and return 
+variables for you, simply within the context of the function itself. As long as variables already exist in the vault, 
+passing a variable to a function is simply a matter of adding the variable to the function signature as a keyword argument. 
+
+The keys in the Keyring allows you to see where your keys are actually being used. By saving arguments to a file or database, 
+it allows you to keep parts of the context the code ran in previously. This can be very useful when deploying something which 
+then has to be un-deployed at a later time that isn't necessarily running in the same process as before. This adds an extra
+layer similar to environment variables that works slightly differently and exclusively in Python. Since the arguments
+can be saved to something like a JSON file, anything that can parse JSON can obviously use the data as they see fit. 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ README = pathlib.Path(f"{HERE}/README.md").read_text()
 
 # Version handling
 # A good way to tell if we are backwards compatible is to run the test suite and if the tests pass without requiring any changes, we can pretty safely assume we are backwards compatible.
-MAJOR = 3  # Change this if the previous MAJOR is incompatible with this build. Set MINOR and PATCH to 0
-MINOR = 1  # Change this if the functionality has changed, but we are still backwards compatible with previous MINOR versions. Set PATCH to 0
+MAJOR = 4  # Change this if the previous MAJOR is incompatible with this build. Set MINOR and PATCH to 0
+MINOR = 0  # Change this if the functionality has changed, but we are still backwards compatible with previous MINOR versions. Set PATCH to 0
 PATCH = 0  # Change this is if we are fixing a bug that doesn't change the functionality. If a bug-fix has caused functionality to be changed, see MINOR instead
 VERSION = f"{MAJOR}.{MINOR}.{PATCH}"
 

--- a/tests/test_large_scale_vault.py
+++ b/tests/test_large_scale_vault.py
@@ -20,7 +20,7 @@ class ResultToUploadDict(varvault.VaultStructDictBase):
         self.logpath = vault_pairs.get("logpath")
 
     @classmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
+    def create(cls, vault_key, vault_value):
         return ResultToUploadDict(**vault_value)
 
 
@@ -32,7 +32,7 @@ class ResultDict(ResultToUploadDict):
         self.version_ha3 = vault_pairs.get("version_ha3")
 
     @classmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
+    def create(cls, vault_key, vault_value):
         return ResultDict(**vault_value)
 
 
@@ -44,18 +44,18 @@ class GroupInstallers(varvault.VaultStructDictBase):
             self.installer_upgrade = installer_upgrade
 
         @classmethod
-        def build_from_vault_key(cls, vault_key, vault_value):
+        def create(cls, vault_key, vault_value):
             return GroupInstallers.Group(**vault_value)
 
     def __init__(self, **vault_pairs):
         super(GroupInstallers, self).__init__(**vault_pairs)
         for group, group_data in vault_pairs.items():
-            self.__setattr__(group, self.Group.build_from_vault_key(vault_key=group,
-                                                                    vault_value=dict(installer=group_data.get("installer"),
-                                                                                     installer_upgrade=group_data.get("installer-upgrade"))))
+            self.__setattr__(group, self.Group.create(vault_key=group,
+                                                      vault_value=dict(installer=group_data.get("installer"),
+                                                                       installer_upgrade=group_data.get("installer-upgrade"))))
 
     @classmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
+    def create(cls, vault_key, vault_value):
         return GroupInstallers(**vault_value)
 
 

--- a/tests/test_live_update.py
+++ b/tests/test_live_update.py
@@ -101,3 +101,19 @@ class TestLiveUpdate:
             assert key_valid_type_is_str == "valid"
             assert key_valid_type_is_int == 1
         validate()
+
+    def test_filehandler_live_update(self):
+        fh = varvault.JsonFilehandler(vault_file_new, live_update=True, create_file_on_live_update=True)
+        assert not fh.exists()
+        fh.create_resource()
+        assert fh.exists()
+        pre_state = fh.state
+        json.dump({Keyring.key_valid_type_is_str: "valid", Keyring.key_valid_type_is_int: 1}, open(vault_file_new, "w"))
+        assert fh.resource_has_changed()
+        assert fh.cached_state != pre_state
+        data = fh.read()
+        assert data[Keyring.key_valid_type_is_str] == "valid"
+        assert data[Keyring.key_valid_type_is_int] == 1
+        fh.update_state()
+
+        assert fh.last_known_state == fh.cached_state

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -17,7 +17,7 @@ class VaultStructDict(varvault.VaultStructDictBase):
         pass
 
     @classmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
+    def create(cls, vault_key, vault_value):
         obj = VaultStructDict(**vault_value)
         return obj
 
@@ -37,7 +37,7 @@ class VaultStructList(varvault.VaultStructListBase):
         pass
 
     @classmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
+    def create(cls, vault_key, vault_value):
         obj = VaultStructList(*vault_value)
         return obj
 
@@ -54,7 +54,7 @@ class VaultStructString(varvault.VaultStructStringBase):
         pass
 
     @classmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
+    def create(cls, vault_key, vault_value):
         obj = VaultStructString(string_value=vault_value, extra_value="extra_value-cannot-possibly-be-saved-to-a-string")
         return obj
 
@@ -71,7 +71,7 @@ class VaultStructFloat(varvault.VaultStructFloatBase):
         pass
 
     @classmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
+    def create(cls, vault_key, vault_value):
         obj = VaultStructFloat(float_value=vault_value, extra_value="extra_value-cannot-possibly-be-saved-to-a-float")
         return obj
 
@@ -88,7 +88,7 @@ class VaultStructInt(varvault.VaultStructIntBase):
         pass
 
     @classmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
+    def create(cls, vault_key, vault_value):
         obj = VaultStructInt(int_value=vault_value, extra_value="extra_value-cannot-possibly-be-saved-to-an-int")
         return obj
 

--- a/varvault/__init__.py
+++ b/varvault/__init__.py
@@ -25,9 +25,9 @@ from .vaultstructs import VaultStructFloatBase
 from .vaultstructs import VaultStructIntBase
 from .vaultstructs import VaultStructStringBase
 
-from .utils import concurrently
+from .utils import AssignedByVault
 from .utils import concurrent_execution
-from .utils import create_mini_vault_from_file
+from .utils import create_mv_from_resource
 
 
 def clear_logs():
@@ -58,52 +58,52 @@ class JsonFilehandler(BaseFileHandler):
         super(JsonFilehandler, self).__init__(path, live_update, vault_is_read_only)
 
     @property
-    def resource(self) -> TextIO:
-        """Returns the file resource object for this handler."""
-        return self.file_io
-
-    # TODO 4.0.0: remove path as an argument from this and expect the subclass to handle this bit
-    def create_resource(self, path: Union[AnyStr, Any]) -> None:
-        """Creates the resource self.file_io for this handler which we'll use to read and write to."""
-        if path and self._live_update and not os.path.exists(path):
-            if self.create_file_on_live_update:
-                self.file_io = open(path, "w")
-                self.file_io.close()
-            else:
-                self.file_io = None
-        elif path and not os.path.exists(path):
-            # Create the file; It doesn't exist. Try to create the folder first.
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-            self.file_io = open(path, "w")
-            self.file_io.close()
-        elif path and os.path.exists(path):
-            # The file already exists; Just read from it
-            self.file_io = open(path)
-            self.file_io.close()
-        else:
-            raise NotImplementedError("This is not supported")
-
-    @property
-    def path(self) -> AnyStr:
-        """Returns the path to the vault-file as a JSON file."""
-        return self.raw_path
-
-    def kv_pair_can_be_written(self, obj: Dict) -> bool:
-        f"""Checks if a key-value pair can be written to a file by attempting to serialize it by using {json.dumps}"""
-        try:
-            json.dumps(obj)
-            return True
-        except (TypeError, OverflowError) as e:
-            return False
-
-    def hash(self) -> str:
-        """Returns the hash for the file, so we can check if the file contains changes compared to what the vault object currently has"""
+    def state(self):
+        """Returns the state of the vault, which is the state of the JSON file"""
         import hashlib
         hash_md5 = hashlib.md5()
         with open(self.path, "rb") as f:
             for chunk in iter(lambda: f.read(4096), b""):
                 hash_md5.update(chunk)
         return hash_md5.hexdigest()
+
+    @property
+    def resource(self) -> TextIO:
+        """Returns the file resource object for this handler."""
+        return self.file_io
+
+    def create_resource(self) -> None:
+        """Creates the resource self.file_io for this handler which we'll use to read and write to."""
+        path = self.path
+        assert path, "Path is not defined"
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+
+        def create():
+            file_io = open(path, "w")
+            json.dump({}, file_io, indent=2)
+            file_io.close()
+            return file_io
+
+        self.file_io = None
+        if self.exists():
+            self.file_io = open(path, "r+")
+        elif not self.live_update:
+            self.file_io = create()
+        elif self.create_file_on_live_update:
+            self.file_io = create()
+
+    @property
+    def path(self) -> AnyStr:
+        """Returns the path to the vault-file as a JSON file."""
+        return self.raw_path
+
+    def writable(self, obj: Dict) -> bool:
+        f"""Checks if a key-value pair in a dict can be written to a file by attempting to serialize it by using {json.dumps}"""
+        try:
+            json.dumps(obj)
+            return True
+        except (TypeError, OverflowError) as e:
+            return False
 
     def exists(self) -> bool:
         """Returns a bool that determines if the JSON file exists by expanding user and potential vars"""

--- a/varvault/filehandlers.py
+++ b/varvault/filehandlers.py
@@ -12,34 +12,54 @@ class BaseFileHandler(abc.ABC):
         self.raw_path = os.path.expanduser(os.path.expandvars(path))
         self.live_update = live_update
         self.vault_is_read_only = vault_is_read_only
+        self.last_known_state = None
+        self.cached_state = None
 
     @property
     def live_update(self):
+        """Returns a bool that says if the resource should be updated live."""
         return self._live_update
 
     @live_update.setter
     def live_update(self, v: bool):
+        """Sets the live-update property."""
         assert isinstance(v, bool), f"Value must be a {bool}"
         self._live_update = v
 
     @property
     def vault_is_read_only(self):
+        """Returns a bool that says if the vault is read-only."""
         return self._vault_is_read_only
 
     @vault_is_read_only.setter
     def vault_is_read_only(self, v: bool):
+        """Sets the read-only state of the vault."""
         assert isinstance(v, bool), f"Value must be a {bool}"
         self._vault_is_read_only = v
+
+    def resource_has_changed(self):
+        """Returns a bool that says if the resource has changed since the last time it was read."""
+        self.last_known_state = self.state
+        return self.cached_state != self.last_known_state
+
+    def update_state(self):
+        """Updates the state by fetching the current state."""
+        self.cached_state = self.last_known_state
 
     @property
     @abc.abstractmethod
     def resource(self) -> Any:
-        """Meant to return the resource that stores the vault in some database."""
+        """Meant to return the resource that stores the vault in some database such as a file."""
         raise NotImplementedError()
 
-    # TODO 4.0.0: remove path as an argument from this and expect the subclass to handle this bit
+    @property
     @abc.abstractmethod
-    def create_resource(self, path: Union[AnyStr, Any]):
+    def state(self):
+        """Meant to return the state of the resource, such as a hash of the resource."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def create_resource(self):
         """Meant to create the resource to store the vault in a database."""
         raise NotImplementedError()
 
@@ -50,13 +70,8 @@ class BaseFileHandler(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def kv_pair_can_be_written(self, obj: Dict) -> bool:
-        """Meant to return a bool that says if a given key-value pair can be successfully written to the database."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def hash(self) -> str:
-        """Meant to return a hash for the database so varvault knows if the vault that is loaded in memory is different from the vault in the file/database."""
+    def writable(self, obj: Dict) -> bool:
+        """Meant to return a bool that says if a given key-value pair in a dict can be successfully written to the database."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -75,12 +90,13 @@ class BaseFileHandler(abc.ABC):
         if self._vault_is_read_only:
             warnings.warn("Tried to write to a vault-file defined as read-only. This is not permitted by varvault.")
         if not self.resource:
-            self.create_resource(self.path)
+            self.create_resource()
         try:
             with self.lock:
                 self.do_write(vault)
         except Exception as e:
             raise ResourceNotFoundError(f"Failed to write to the resource: {e}", self)
+        self.update_state()
 
     @abc.abstractmethod
     def do_write(self, vault: dict) -> None:
@@ -89,7 +105,8 @@ class BaseFileHandler(abc.ABC):
         The class that implements this abstract method has to write a dict to a resource.
 
         Example:
-        `json.dump(vault, open(self.path, "w"), indent=2)`
+
+        ``json.dump(vault, open(self.path, "w"), indent=2)``
 
         :param vault: The vault to write to the file.
         :return: None. Varvault will not use the return value from this function
@@ -102,9 +119,10 @@ class BaseFileHandler(abc.ABC):
     def read(self) -> Dict:
         f"""Reads the vault from the database by calling the implemented '{self.do_read}' method."""
         if not self.resource:
-            self.create_resource(self.path)
+            self.create_resource()
         try:
             with self.lock:
+                self.update_state()
                 return self.do_read()
         except Exception as e:
             if self.live_update:
@@ -120,9 +138,10 @@ class BaseFileHandler(abc.ABC):
         The class that implements this abstractmethod has to read data from a file and then return it.
 
         Example:
-        `return json.load(open(self.path))`
 
-        :return: A dict describing the vault from the file.
+        ``return json.load(open(self.path))``
+
+        :return: A dict describing the vault from the resource.
         """
         raise NotImplementedError()
 

--- a/varvault/keyring.py
+++ b/varvault/keyring.py
@@ -90,7 +90,7 @@ class Keyring(object):
     Note that you never have to instantiate this class (i.e. create an object), you just have to create a class that inherits from this class."""
 
     @classmethod
-    def get_keys_in_keyring(cls) -> Dict[str, Key]:
+    def get_keys(cls) -> Dict[str, Key]:
         """Returns all keys in the keyring as a dict on this format: Dict[str: Key]"""
         keys = dict()
         for key, value in cls.__dict__.items():
@@ -107,4 +107,4 @@ class Keyring(object):
             return cls.__dict__[key_str]
         except KeyError:
             raise KeyError(f"Failed to get matching key for string: {key_str}. "
-                           f"It doesn't appear to exist in the keyring: {cls.get_keys_in_keyring().values()}")
+                           f"It doesn't appear to exist in the keyring: {cls.get_keys().values()}")

--- a/varvault/minivault.py
+++ b/varvault/minivault.py
@@ -34,3 +34,11 @@ class MiniVault(dict):
     def add(self, k, v):
         """Adds a value mapped to a key. Essentially just wraps the '__setitem__' function."""
         self.__setitem__(k, v)
+
+    def keys(self) -> List[Key]:
+        """Returns a list of keys"""
+        return list(super(MiniVault, self).keys())
+
+    def values(self) -> List[Any]:
+        """Returns a list of values"""
+        return list(super(MiniVault, self).values())

--- a/varvault/vaultfactory.py
+++ b/varvault/vaultfactory.py
@@ -7,7 +7,7 @@ from .keyring import Keyring
 from .minivault import MiniVault
 from .vaultflags import VaultFlags
 from .vault import VarVault
-from .utils import create_mini_vault_from_file
+from .utils import create_mv_from_resource
 
 
 def create_vault(varvault_keyring: Type[Keyring],
@@ -68,9 +68,9 @@ def from_vault(varvault_keyring: Type[Keyring],
     if not varvault_filehandler_to:
         varvault_filehandler_to = varvault_filehandler_from
 
-    keys_not_in_keyring = _check_for_keys_not_in_keyring(varvault_keyring, varvault_filehandler_from, ignore_keys_not_in_keyring, *flags, **extra_keys)
+    keys_not_in_keyring = _check_for_keys_not_in_keyring(varvault_keyring, varvault_filehandler_from, ignore_keys_not_in_keyring, **extra_keys)
     if varvault_filehandler_from.exists():
-        mini = create_mini_vault_from_file(varvault_filehandler_from, varvault_keyring, **extra_keys)
+        mini = create_mv_from_resource(varvault_filehandler_from, varvault_keyring, **extra_keys)
     elif not varvault_filehandler_from.exists() and VaultFlags.flag_is_set(VaultFlags.live_update(), *flags):
         mini = MiniVault()
     else:
@@ -92,11 +92,11 @@ def from_vault(varvault_keyring: Type[Keyring],
     return vault
 
 
-def _check_for_keys_not_in_keyring(varvault_keyring: Type[Keyring], varvault_filehandler_from: BaseFileHandler, ignore_keys_not_in_keyring: bool, *flags: VaultFlags, **extra_keys):
+def _check_for_keys_not_in_keyring(varvault_keyring: Type[Keyring], varvault_filehandler_from: BaseFileHandler, ignore_keys_not_in_keyring: bool, **extra_keys):
     vault_file_data = varvault_filehandler_from.read()
 
     assert isinstance(vault_file_data, dict), f"It appears we were not able to load a Dict from {varvault_filehandler_from}. Are you sure this is a valid resource? (content={vault_file_data})"
-    keys_in_keyring = varvault_keyring.get_keys_in_keyring()
+    keys_in_keyring = varvault_keyring.get_keys()
     keys_in_keyring.update(extra_keys)
     keys_in_file = vault_file_data.keys()
     _keys_not_in_keyring = [k for k in keys_in_file if k not in keys_in_keyring]

--- a/varvault/vaultflags.py
+++ b/varvault/vaultflags.py
@@ -18,6 +18,9 @@ class VaultFlags(str):
         elif isinstance(other, str):
             return self.name == other
 
+    def __hash__(self):
+        return hash(self.name)
+
     @staticmethod
     def flag_is_set(flag: VaultFlags, *flags: VaultFlags):
         f"""This is not a flag. This function checks if a flag exists among a bunch of flags"""
@@ -107,3 +110,11 @@ class VaultFlags(str):
         f"""Flag to tell a vaulter-decorated function to not log exceptions. Exceptions can sometimes be expected,
         and sometimes it might be preferable to not log errors using varvault and just log them normally."""
         return VaultFlags(VaultFlags.no_error_logging.__name__)
+
+    @staticmethod
+    def use_signature_for_input_keys():
+        f"""Flag to tell varvault to use the keyword args in the signature of a decorated function to determine the keys to extract from the vault. This effectively removes 
+        the need to define input keys through the decorator. Instead, you just need to define the input keys in the signature of the decorated function by calling the keyword 
+        argument the same as the key. This will make tracking where the keys in the Keyring are used harder, but reduces the amount of boilerplate required. Can be defined 
+        for the entire vault, or for a specific decorated function only."""
+        return VaultFlags(VaultFlags.use_signature_for_input_keys.__name__)

--- a/varvault/vaultstructs.py
+++ b/varvault/vaultstructs.py
@@ -4,8 +4,8 @@ import abc
 class VaultStructBase(abc.ABC):
     @classmethod
     @abc.abstractmethod
-    def build_from_vault_key(cls, vault_key, vault_value):
-        raise NotImplementedError(f"{cls.build_from_vault_key.__name__} was not implemented in the subclass that inherited this.")
+    def create(cls, vault_key, vault_value):
+        raise NotImplementedError(f"{cls.create.__name__} was not implemented in the subclass that inherited this.")
 
 
 class VaultStructDictBase(VaultStructBase, dict, abc.ABC):


### PR DESCRIPTION
New features:
* Added the possibility to define input keys through the name of the parameters in the signature of the function. It essentially comes down to calling a parameter the same as the name of a key in the keyring and making sure the flag `VaultFlags.use_signature_for_input_keys` is defined. This can reduce boilerplate, but does make it harder to track the usage of certain keys, which is why it will never be the default behavior of varvault.

Other changes:
* Updated the conclusion section of the README.md.
* Reworked the filehandlers API and simplified the JsonFileHandler slightly.
  * The filehandler now holds the state and keeps track of it, rather than varvault itself keeping track of the state.
* Made changes to the vaultstructs API to change the name of the abstract method to `create` which is a lot less cumbersome of a function name.
* Made significant cleanup of code, mostly in vault.py to make it easier to work with, and to read and comprehend.