### PR TITLE
6.0.0: Feature branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,5 @@ test: clear-logs
 	@coverage run --source=varvault -m pytest --tb=short --junitxml ./logs/test-report.xml -vvv --full-trace -p no:cacheprovider --html=./logs/test-report.html --self-contained-html $(shell ls tests/test_*.py)
 	@coverage html -d ./logs/coverage-report
 	@coverage json -o ./logs/coverage-report/coverage.json --pretty-print
-	@python3 -c "import json; assert json.load(open('./logs/coverage-report/coverage.json'))['totals']['percent_covered'] == 100.0, 'Coverage is not 100%'" && echo "Coverage is 100%"
+	@python3 -c "import json; assert json.load(open('./logs/coverage-report/coverage.json'))['totals']['percent_covered'] == 100.0, 'Coverage is not 100%'; print('Coverage is 100%')"
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip3 install varvault
 ```
 
 ### Contact
-calle.holst@dataductus.se
+chloe.holst@dataductus.se
 
 
 ## What is this? 
@@ -22,46 +22,47 @@ You can then use a decorator to annotate functions that you want to have use thi
 in or to extract variables to be used as input for the function.  
 
 ## How does it work? 
-The way this works is that when you write a function, you annotate it with a special decorator (`varvault.Vault.vaulter`)
-that takes some arguments. This decorator will then handle any input arguments and return variables for you.
+The way this works is that when you write a function, you annotate it with a special decorator (`varvault.Vault.manual` or `varvault.Vault.automatic`)
+that takes some arguments. The decorator will then handle any input arguments and return variables for you.
 The decorator takes some arguments that defines certain keys and flags to tweak the behavior.
 
 ### How about an example?
-The best examples can be found in the test suites which can give a very good idea how it works and is guaranteed to be up-to-date. 
+The best examples can be found in the test suites which can give a very good idea how it works and is guaranteed to be up-to-date.
+
 ```python
 import varvault
 
 
 class Keyring(varvault.Keyring):
-    arg1 = varvault.Key("arg1", valid_type=int)
-    arg2 = varvault.Key("arg2", valid_type=int)
+   arg1 = varvault.Key("arg1", valid_type=int)
+   arg2 = varvault.Key("arg2", valid_type=int)
 
 
 vault = varvault.create(keyring=Keyring, resource=varvault.JsonResource("~/test.json", mode=varvault.ResourceModes.WRITE))
 
 
-@vault.vaulter(return_keys=[Keyring.arg1, Keyring.arg2])
+@vault.manual(output=(Keyring.arg1, Keyring.arg2))
 def create_args(arg1, arg2):
-    return arg1, arg2
+   return arg1, arg2
 
 
-@vault.vaulter(input_keys=[Keyring.arg1, Keyring.arg2])
+@vault.manual(input=(Keyring.arg1, Keyring.arg2))
 def use_args(arg1: int = varvault.AssignedByVault, arg2: int = varvault.AssignedByVault):
-    print(f"{Keyring.arg1}: {arg1}, {Keyring.arg2}: {arg2}")
+   print(f"{Keyring.arg1}: {arg1}, {Keyring.arg2}: {arg2}")
 
 
 def run_create_args():
-    create_args(1, 2)
-    
+   create_args(1, 2)
+
 
 def run_use_args():
-    use_args()
+   use_args()
 
 
 if __name__ == "__main__":
-    run_create_args()
-    
-    run_use_args()    
+   run_create_args()
+
+   run_use_args()    
 ```
 1. In this example, we start by creating a class that defines a keyring. This keyring will be the keys used
    in the vault. Any key you use for storing variables or take variables out should be defined as a constant 
@@ -72,29 +73,29 @@ if __name__ == "__main__":
    a single argument to be defined and that is a class that inherits from the `varvault.Keyring` (a class based on the Keyring class here).
    Optionally, you can define some flags to further tweak the behavior of the vault. These tweaked behaviors include
    allowing for existing key-value pairs to be modified (this is not allowed by default), allowing return variables from
-   functions defined with return keys to be None, and setting a flag to write some additional debug logs.
+   functions defined with output keys to be `None`, and setting a flag to write some additional debug logs.
    We also define the input parameter `resource` which is a `varvault.JsonResource` object that points to a `.JSON` file. This resource will be used  
    as a vault file to store all the arguments in. 
 
 3. We define a function called `create_args` that takes some arguments (we have to insert variables
    into the vault somehow, right?) that we annotate with the vault decorator. We pass an argument to the
-   decorator called `return_keys`. This argument tells the vault which keys this function will assign its
-   return variables to. Note that the order of the return keys matter. In this case, the ingoing argument `arg1` will
+   decorator called `ouput`. This argument tells the vault which keys this function will assign its
+   return variables to. Note that the order of the output keys matter. In this case, the ingoing argument `arg1` will
    be assigned to `Keyring.arg1`, and the ingoing argument `arg2` will be assigned to `Keyring.arg2`. It's very possible
-   to set `return_keys` to a single `Key` as well if you only have one variable to return. If you want more control
+   to set `output` to a single `Key` as well if you only have one variable to return. If you want more control
    over how return variables are handled, please see `varvault.MiniVault` and make use of that to ensure that
    return-variables are handled exactly as you want. 
    
    **Note:** When this function is called, and it finishes, the decorator here will capture the return variables and then store 
-   those return variables in the vault with the keys that were passed to the decorator as `return_keys`. These variables can then be 
+   those return variables in the vault with the keys that were passed to the decorator as `output`. These variables can then be 
    accessed by another function that uses the same vault-object as this one does to decorate a function.
 
 4. We then create a new function called `use_args` that we also annotate with the vault decorator. We pass a different
-   argument to the decorator this time called `input_keys`. This argument tells the vault which keys in the vault
+   argument to the decorator this time called `input`. This argument tells the vault which keys in the vault
    we want passed to this function. The order of the keys doesn't really matter here, the order is mostly aesthetic.
    
    **Note:** What ends up happening when this function is called, is that the decorator will try to extract keys defined in
-   `input_keys` from the vault and then pass those variables to the function as a dictionary (by defining the arguments as
+   `input` from the vault and then pass those variables to the function as a dictionary (by defining the arguments as
    keyword arguments, these arguments won't need to be provided when the method is called). 
    It is possible to just bundle all the arguments in the signature of the function as a `**kwargs` structure (in this case the signature
    would be `def use_args(**kwargs)`). One of the benefits of doing like in the example is that you can easily see what 
@@ -131,7 +132,7 @@ if __name__ == "__main__":
                            resource=varvault.JsonResource("~/test.json", mode=varvault.ResourceModes.APPEND))
    ```
    When re-creating a vault from an existing file it's recommended to allow modifications 
-   (see `varvault.VaultFlags.permit_modifications`) in-case you are planning to write the same
+   (see `varvault.Flags.permit_modifications`) in-case you are planning to write the same
    arguments to the vault again. 
 
 ## Conclusion

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ README = pathlib.Path(f"{HERE}/README.md").read_text()
 
 # Version handling
 # A good way to tell if we are backwards compatible is to run the test suite and if the tests pass without requiring any changes, we can pretty safely assume we are backwards compatible.
-MAJOR = 5  # Change this if the previous MAJOR is incompatible with this build. Set MINOR and PATCH to 0
+MAJOR = 6  # Change this if the previous MAJOR is incompatible with this build. Set MINOR and PATCH to 0
 MINOR = 0  # Change this if the functionality has changed, but we are still backwards compatible with previous MINOR versions. Set PATCH to 0
-PATCH = 3  # Change this is if we are fixing a bug that doesn't change the functionality. If a bug-fix has caused functionality to be changed, see MINOR instead
+PATCH = 0  # Change this is if we are fixing a bug that doesn't change the functionality. If a bug-fix has caused functionality to be changed, see MINOR instead
 VERSION = f"{MAJOR}.{MINOR}.{PATCH}"
 
 

--- a/tests/test_automatic.py
+++ b/tests/test_automatic.py
@@ -1,0 +1,326 @@
+import tempfile
+import time
+
+import pytest
+
+from commons import *
+
+vault_file_new = f"{DIR}/new-vault.json"
+vault_file_new_secondary = f"{DIR}/new-vault-secondary.json"
+existing_vault = f"{DIR}/existing-vault.json"
+faulty_existing_vault = f"{DIR}/faulty-existing-vault.json"
+faulty_vault_key_missmatch = f"{DIR}/faulty-vault-key-missmatch.json"
+
+
+class KeyringSubscriber(varvault.Keyring):
+    trigger = varvault.Key("trigger", valid_type=str)
+    first = varvault.Key("first", valid_type=str)
+    second = varvault.Key("second", valid_type=str)
+    third = varvault.Key("third", valid_type=str)
+    final = varvault.Key("final", valid_type=str)
+
+
+class TestSubscriber:
+
+    @classmethod
+    def setup_class(cls):
+        tempfile.tempdir = "/tmp" if sys.platform == "darwin" or sys.platform == "linux" else tempfile.gettempdir()
+
+    def setup_method(self):
+        try:
+            os.remove(vault_file_new)
+        except:
+            pass
+        try:
+            os.remove(vault_file_new_secondary)
+        except:
+            pass
+
+    def test_dev(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+
+        # Define a subscriber that will be triggered when the value for the key 'first' is inserted into the vault
+        @vault.automatic(input=KeyringSubscriber.first, output=KeyringSubscriber.second)
+        def f(first: str = varvault.AssignedByVault):
+            return first + "2"
+
+        # Inserting a value for the key 'first' into the vault will trigger the subscriber defined above
+        vault.insert(KeyringSubscriber.first, "go")
+
+        # The subscriber will be called and the value for the key 'second' will be set
+        assert KeyringSubscriber.second in vault
+
+        # The value for the key 'second' should be 'go2'
+        assert vault.get(KeyringSubscriber.second) == "go2"
+
+    def test_subscriber(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+        called_first = False
+        called_second = False
+        called_third = False
+
+        @vault.automatic(input=KeyringSubscriber.first, output=KeyringSubscriber.second)
+        def one(first: str = varvault.AssignedByVault):
+            nonlocal called_first
+            called_first = True
+            assert isinstance(first, str)
+            return "will trigger second"
+
+        @vault.automatic(input=KeyringSubscriber.second, output=KeyringSubscriber.third)
+        def two(second: str = varvault.AssignedByVault):
+            nonlocal called_second
+            called_second = True
+            assert isinstance(second, str)
+            return "will trigger third"
+
+        @vault.automatic(input=KeyringSubscriber.third, output=KeyringSubscriber.final)
+        def three(third: str = varvault.AssignedByVault):
+            nonlocal called_third
+            called_third = True
+            assert isinstance(third, str)
+            return "final"
+
+        @vault.manual(output=KeyringSubscriber.first)
+        def start():
+            return "first"
+
+        # This will trigger function 'one', which will trigger function 'two', which will trigger function 'three'
+        start()
+
+        # All functions should have been called
+        assert called_first
+        assert called_second
+        assert called_third
+
+        # All keys should have been set to the following expected values
+        assert vault.get(KeyringSubscriber.first) == "first"
+        assert vault.get(KeyringSubscriber.second) == "will trigger second"
+        assert vault.get(KeyringSubscriber.third) == "will trigger third"
+        assert vault.get(KeyringSubscriber.final) == "final"
+
+    def test_no_keys(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+        called = False
+
+        @vault.automatic()
+        def sub():
+            nonlocal called
+            called = True
+
+        sub()
+
+        # All functions should have been called
+        assert called
+
+    def test_subscriber_threaded(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+        called_first = False
+        called_second = False
+        called_third = False
+        sleep_dur = 2
+
+        @vault.automatic(threaded=True, input=KeyringSubscriber.trigger, output=KeyringSubscriber.first)
+        def one(**kwargs):
+            logger.info("one")
+            nonlocal called_first
+            called_first = True
+            time.sleep(sleep_dur)
+            return "first"
+
+        @vault.automatic(threaded=True, input=KeyringSubscriber.trigger, output=KeyringSubscriber.second)
+        def two(**kwargs):
+            logger.info("two")
+            nonlocal called_second
+            called_second = True
+            time.sleep(sleep_dur)
+            return "second"
+
+        @vault.automatic(threaded=True, input=KeyringSubscriber.trigger, output=KeyringSubscriber.third)
+        def three(**kwargs):
+            logger.info("three")
+            nonlocal called_third
+            called_third = True
+            time.sleep(sleep_dur)
+            return "third"
+
+        @vault.manual(output=KeyringSubscriber.trigger)
+        def start():
+            return "go"
+
+        @vault.automatic(input=(KeyringSubscriber.first, KeyringSubscriber.second, KeyringSubscriber.third),
+                         output=KeyringSubscriber.final)
+        def final(first, second, third):
+            return first + second + third
+
+        start()
+
+        # If this fails, it's probably due to I/O contention. Try increasing the sleep duration.
+        # KeyringSubscriber.final will be written to the vault sooner than it seems, but the different automatic functions
+        # will lock the vault when they write, so a short sleep will mean the effect of I/O has a larger impact on the result.
+        # Try increasing and lowering the sleep duration to see how it affects the duration of the test.
+        vault.await_running_tasks(timeout=sleep_dur * 3, exception=TimeoutError(f"All tasks should have completed within {sleep_dur * 3} seconds. Methods appear to run in sequence"))
+
+        assert len(vault.running_tasks) == 0, "All tasks should have completed and not be listed as running"
+        # All functions should have been called
+        assert called_first and vault.get(KeyringSubscriber.first) == "first"
+        assert called_second and vault.get(KeyringSubscriber.second) == "second"
+        assert called_third and vault.get(KeyringSubscriber.third) == "third"
+
+        with pytest.raises(ValueError) as e:
+            @vault.automatic()
+            async def async_func():
+                pass
+        assert f"Async subscriber functions do not work because async functions cannot truly run in the background. Use {vault.automatic.__name__} with 'threaded=True' instead." in str(e.value)
+
+    def test_subscriber_with_existing_vault(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+        vault.insert(KeyringSubscriber.trigger, "go")
+
+        vault_recreated = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="a"))
+
+        # Registering this subscriber will not trigger the function since the vault does not have the relevant keys yet, but will receive them
+        @vault_recreated.automatic(input=(KeyringSubscriber.first, KeyringSubscriber.second, KeyringSubscriber.third),
+                                   output=KeyringSubscriber.final)
+        def final(first, second, third):
+            return first + second + third
+
+        # Registering this subscriber will trigger the function immediately since the vault already has the relevant keys, which in turn will trigger the function above
+        @vault_recreated.automatic(input=(KeyringSubscriber.trigger,),
+                                   output=(KeyringSubscriber.first, KeyringSubscriber.second, KeyringSubscriber.third))
+        def trigger_function(trigger: str = varvault.AssignedByVault):
+            return "first", "second", "third"
+
+        assert vault_recreated.get(KeyringSubscriber.final) == "firstsecondthird"
+
+    def test_with_clean_keys(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+        vault.insert(KeyringSubscriber.trigger, "go")
+
+        vault_recreated = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="a"))
+
+        # Registering this subscriber will not trigger the function since the vault does not have the relevant keys yet, but will receive them
+        @vault_recreated.automatic(input=(KeyringSubscriber.first, KeyringSubscriber.second, KeyringSubscriber.third),
+                                   output=KeyringSubscriber.final)
+        def final(first, second, third):
+            return first + second + third
+
+        # Registering this subscriber will trigger the function immediately since the vault already has the relevant keys, which in turn will trigger the function above
+        @vault_recreated.automatic(input=(KeyringSubscriber.trigger,),
+                                   output=(KeyringSubscriber.first, KeyringSubscriber.second, KeyringSubscriber.third))
+        def trigger_function(trigger: str = varvault.AssignedByVault):
+            return "first", "second", "third"
+
+        @vault_recreated.automatic(varvault.Flags.clean_output_keys,
+                                   input=(KeyringSubscriber.final,),
+                                   output=(KeyringSubscriber.first, KeyringSubscriber.second, KeyringSubscriber.third))
+        def clean(final: str = varvault.AssignedByVault):
+            return
+
+        assert vault_recreated.get(KeyringSubscriber.final) == "firstsecondthird"
+        assert vault_recreated.get(KeyringSubscriber.first) == ""
+        assert vault_recreated.get(KeyringSubscriber.second) == ""
+        assert vault_recreated.get(KeyringSubscriber.third) == ""
+
+    def test_conditional(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+        vault.insert(KeyringSubscriber.trigger, "go")
+
+        vault_recreated = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="a"))
+
+        # Registering this subscriber will not trigger the function since the vault does not have the relevant keys yet, but will receive them
+        @vault_recreated.automatic(input=(KeyringSubscriber.first, KeyringSubscriber.second, KeyringSubscriber.third),
+                                   output=KeyringSubscriber.final)
+        def final(first, second, third):
+            return first + second + third
+
+        did_not_get_called = True
+
+        @vault_recreated.automatic(condition=lambda: vault_recreated.get(KeyringSubscriber.trigger) == "don't go",
+                                   input=(KeyringSubscriber.trigger,),
+                                   output=(KeyringSubscriber.first, KeyringSubscriber.second, KeyringSubscriber.third))
+        def should_not_be_called(trigger: str = varvault.AssignedByVault):
+            nonlocal did_not_get_called
+            did_not_get_called = False
+            logger.info(f"should_not_be_called: {trigger}")
+            return "first", "second", "third"
+
+        did_get_called = False
+
+        @vault_recreated.automatic(condition=lambda: vault_recreated.get(KeyringSubscriber.trigger) == "go",
+                                   input=(KeyringSubscriber.trigger,),
+                                   output=(KeyringSubscriber.first, KeyringSubscriber.second, KeyringSubscriber.third))
+        def should_be_called(trigger: str = varvault.AssignedByVault):
+            nonlocal did_get_called
+            did_get_called = True
+            logger.info(f"should_be_called: {trigger}")
+            return "first", "second", "third"
+
+        assert did_not_get_called
+        assert did_get_called
+        assert vault_recreated.get(KeyringSubscriber.final) == "firstsecondthird"
+
+    def test_output_replaces_input(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+
+        @vault.automatic(input=(KeyringSubscriber.trigger,),
+                         output=(KeyringSubscriber.first,))
+        def first(trigger: str = varvault.AssignedByVault):
+            return "first"
+
+        @vault.automatic(varvault.Flags.output_key_replaces_input_key,
+                         input=(KeyringSubscriber.first,),
+                         output=(KeyringSubscriber.second,))
+        def second(first: str = varvault.AssignedByVault):
+            assert first == "first"
+            return "second"
+
+        @vault.manual(varvault.Flags.output_key_replaces_input_key,
+                      input=(KeyringSubscriber.trigger, KeyringSubscriber.second,),
+                      output=(KeyringSubscriber.third,))
+        def third(trigger: str = varvault.AssignedByVault,
+                  second: str = varvault.AssignedByVault):
+            assert trigger == "go"
+            assert second == "second"
+            return "third"
+
+        vault.insert(KeyringSubscriber.trigger, "go")
+        assert KeyringSubscriber.first not in vault
+        assert KeyringSubscriber.first not in vault.writable_args
+        assert vault.get(KeyringSubscriber.second) == "second"
+        with pytest.raises(ValueError) as e:
+            third()
+        assert f"If {varvault.Flags.output_key_replaces_input_key} is defined, you MUST define exactly one input key and one output key." in str(e.value)
+
+    def test_verify_input_output_cannot_contain_same_key(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+
+        with pytest.raises(KeyError) as e:
+            @vault.automatic(input=(KeyringSubscriber.trigger,),
+                             output=(KeyringSubscriber.trigger,))
+            def first(trigger: str = varvault.AssignedByVault):
+                return "first"
+
+        assert f"input and output cannot contain the same keys" in str(e.value)
+
+    def test_with_permit_modifications(self):
+        vault = varvault.create(keyring=KeyringSubscriber, resource=varvault.JsonResource(vault_file_new, mode="w"))
+
+        @vault.automatic(varvault.Flags.permit_modifications,
+                         input=(KeyringSubscriber.trigger,),
+                         output=(KeyringSubscriber.first,))
+        def first(trigger: str = varvault.AssignedByVault):
+            return trigger + "first"
+
+        vault.insert(KeyringSubscriber.trigger, "go")
+        assert vault.get(KeyringSubscriber.first) == "gofirst"
+        vault.insert(KeyringSubscriber.trigger, "go-again", varvault.Flags.permit_modifications)
+        assert vault.get(KeyringSubscriber.first) == "go-againfirst"
+
+        with pytest.raises(KeyError) as e:
+            @vault.automatic(input=(KeyringSubscriber.trigger,),
+                             output=(KeyringSubscriber.first,))
+            def new_first(trigger: str = varvault.AssignedByVault):
+                return trigger + "first"
+            vault.insert(KeyringSubscriber.trigger, "go-again", varvault.Flags.permit_modifications)
+        # This should br triggered by the decorated function, hence why we check KeyringSubscriber.first is in the error string, not KeyringSubscriber.trigger.
+        assert f"Key {KeyringSubscriber.first} already exists in the vault" in str(e.value)

--- a/tests/test_large_scale_vault.py
+++ b/tests/test_large_scale_vault.py
@@ -237,7 +237,7 @@ class TestLargeScaleVault:
                 KeyringLargeScale.result,
                 ]
 
-        @vault.vaulter(input_keys=keys)
+        @vault.manual(input=keys)
         def _get(**kwargs):
             assert len([k for k in keys if k in kwargs]) == len(keys)
         _get()
@@ -292,7 +292,7 @@ class TestLargeScaleVault:
 
         # Note the use of varvault.Flags.silent here. It will speed up the processing significantly.
         # It brings processing down from 3 seconds to 0.6 seconds for 500 parallel requests.
-        @vault.vaulter(varvault.Flags.silent, input_keys=keys)
+        @vault.manual(varvault.Flags.silent, input=keys)
         async def _get(thread_id, **kwargs):
             assert isinstance(thread_id, int)
             assert len([k for k in keys if k in kwargs]) == len(keys)
@@ -358,7 +358,7 @@ class TestLargeScaleVault:
         json.dump(contents, open(vault_file_new, "w"), indent=2)
 
         # Since we use live update, the contents of the existing vault file should now be loaded into the vault.
-        @vault.vaulter(input_keys=keys)
+        @vault.manual(input=keys)
         def _get(**kwargs):
             assert len([k for k in keys if k in kwargs]) == len(keys)
         _get()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -41,7 +41,7 @@ class TestLogging:
         vault_new = varvault.create(varvault.Flags.silent, varvault.Flags.remove_existing_log_file, keyring=Keyring, resource=varvault.JsonResource(vault_file_new, mode="w"))
         vault_new.logger.addHandler(logging.StreamHandler(open(temp_log_file, "w")))
 
-        @vault_new.vaulter(return_keys=Keyring.key_valid_type_is_str)
+        @vault_new.manual(output=Keyring.key_valid_type_is_str)
         def _set():
             return "valid"
         _set()
@@ -59,7 +59,7 @@ class TestLogging:
         # This way, we can easily capture stdout to a file and assert that the output is the expected
         vault_new.logger.addHandler(logging.StreamHandler(open(temp_log_file, "w")))
 
-        @vault_new.vaulter(return_keys=Keyring.key_valid_type_is_str)
+        @vault_new.manual(output=Keyring.key_valid_type_is_str)
         def _set():
             return "valid"
         _set()
@@ -69,7 +69,7 @@ class TestLogging:
         assert len(open(vault_log_file).readlines()) >= 12, f"There appears to be fewer lines in the log file than what there should be. " \
                                                             f"There should only be 12 at least. {varvault.Flags.debug} appears to not function correctly"
 
-        @vault_new.vaulter(input_keys=Keyring.key_valid_type_is_str)
+        @vault_new.manual(input=Keyring.key_valid_type_is_str)
         def _use(key_valid_type_is_str: str = varvault.AssignedByVault):
             return key_valid_type_is_str
 
@@ -83,7 +83,7 @@ class TestLogging:
         # This way, we can easily capture stdout to a file and assert that the output is the expected
         vault_new.logger.addHandler(logging.StreamHandler(open(temp_log_file, "w")))
 
-        @vault_new.vaulter(varvault.Flags.silent, return_keys=Keyring.key_valid_type_is_str)
+        @vault_new.manual(varvault.Flags.silent, output=Keyring.key_valid_type_is_str)
         def _set():
             return "valid"
         _set()
@@ -105,7 +105,7 @@ class TestLogging:
         assert vault_new.logger is None, "logger object is not None; it should be"
         assert not os.path.exists(vault_log_file), f"{vault_log_file} exists after creating the vault when saying there shouldn't be a logger object"
 
-        @vault_new.vaulter(varvault.Flags.silent, return_keys=Keyring.key_valid_type_is_str)
+        @vault_new.manual(varvault.Flags.silent, output=Keyring.key_valid_type_is_str)
         def _set():
             return "valid"
         _set()
@@ -115,7 +115,7 @@ class TestLogging:
         vault_log_file = os.path.join(tempfile.gettempdir(), "varvault-logs", "varvault.log")
         vault_new = varvault.create(varvault.Flags.debug, keyring=Keyring, resource=varvault.JsonResource(vault_file_new, mode="w"))
 
-        @vault_new.vaulter(varvault.Flags.silent, return_keys=Keyring.key_valid_type_is_str)
+        @vault_new.manual(varvault.Flags.silent, output=Keyring.key_valid_type_is_str)
         def _doset():
             return "valid"
         _doset()
@@ -149,7 +149,7 @@ class TestLogging:
             vault_new = varvault.create(varvault.Flags.debug, varvault.Flags.remove_existing_log_file, keyring=Keyring, resource=varvault.JsonResource(vault_file_new, mode="w"), logger=logger)
             assert vault_new.logger.name == "pytest"  # The logger used for pytest here is called pytest
 
-            @vault_new.vaulter(varvault.Flags.silent, return_keys=Keyring.key_valid_type_is_str)
+            @vault_new.manual(varvault.Flags.silent, output=Keyring.key_valid_type_is_str)
             def _set():
                 return "valid"
             _set()
@@ -170,7 +170,7 @@ class TestLogging:
         # This way, we can easily capture stdout to a file and assert that the output is the expected
         vault_new.logger.addHandler(logging.StreamHandler(open(temp_log_file, "w")))
 
-        @vault_new.vaulter(varvault.Flags.no_error_logging, return_keys=Keyring.key_valid_type_is_str)
+        @vault_new.manual(varvault.Flags.no_error_logging, output=Keyring.key_valid_type_is_str)
         def _set():
             raise Exception("Failing deliberately")
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -126,7 +126,7 @@ class TestVaultStructs:
     def test_vault_struct_dict(self):
         vault = varvault.create(keyring=KeyringVaultStruct, resource=varvault.JsonResource(vault_file_new, mode="w"))
 
-        @vault.vaulter(return_keys=KeyringVaultStruct.key_vault_struct_dict)
+        @vault.manual(output=KeyringVaultStruct.key_vault_struct_dict)
         def _set():
             return VaultStructDict("v1", 1)
 
@@ -147,7 +147,7 @@ class TestVaultStructs:
     def test_vault_struct_list(self):
         vault = varvault.create(keyring=KeyringVaultStruct, resource=varvault.JsonResource(vault_file_new, mode="w"))
 
-        @vault.vaulter(return_keys=KeyringVaultStruct.key_vault_struct_list)
+        @vault.manual(output=KeyringVaultStruct.key_vault_struct_list)
         def _set():
             return VaultStructList("v1", 1)
 
@@ -164,7 +164,7 @@ class TestVaultStructs:
     def test_vault_struct_string(self):
         vault = varvault.create(keyring=KeyringVaultStruct, resource=varvault.JsonResource(vault_file_new, mode="w"))
 
-        @vault.vaulter(return_keys=KeyringVaultStruct.key_vault_struct_string)
+        @vault.manual(output=KeyringVaultStruct.key_vault_struct_string)
         def _set():
             return VaultStructString("string-value", "extra-value-here")
 
@@ -180,7 +180,7 @@ class TestVaultStructs:
     def test_vault_struct_float(self):
         vault = varvault.create(keyring=KeyringVaultStruct, resource=varvault.JsonResource(vault_file_new, mode="w"))
 
-        @vault.vaulter(return_keys=KeyringVaultStruct.key_vault_struct_float)
+        @vault.manual(output=KeyringVaultStruct.key_vault_struct_float)
         def _set():
             return VaultStructFloat(3.14, "extra-value-here")
 
@@ -196,7 +196,7 @@ class TestVaultStructs:
     def test_vault_struct_int(self):
         vault = varvault.create(keyring=KeyringVaultStruct, resource=varvault.JsonResource(vault_file_new, mode="w"))
 
-        @vault.vaulter(return_keys=KeyringVaultStruct.key_vault_struct_int)
+        @vault.manual(output=KeyringVaultStruct.key_vault_struct_int)
         def _set():
             return VaultStructInt(1, "extra-value-here")
         _set()
@@ -212,7 +212,7 @@ class TestVaultStructs:
     def test_invalid_vault_struct(self):
         vault = varvault.create(keyring=KeyringVaultStruct, resource=varvault.JsonResource(vault_file_new, mode="w"))
 
-        @vault.vaulter(return_keys=KeyringVaultStruct.key_vault_struct_dict_invalid)
+        @vault.manual(output=KeyringVaultStruct.key_vault_struct_dict_invalid)
         def _set():
             return VaultStructDictInvalid("v1", 1)
 

--- a/tests/test_xml_vault.py
+++ b/tests/test_xml_vault.py
@@ -22,7 +22,7 @@ class XmlResource(varvault.BaseResource):
     def resource(self) -> TextIO:
         return self.file_io
 
-    def create_resource(self) -> None:
+    def create(self) -> None:
         """Creates the resource self.file_io for this handler which we'll use to read and write to."""
         path = self.path
         assert path, "Path is not defined"
@@ -108,7 +108,7 @@ class TestXmlVault:
     def test_create_xml_vault(self):
         vault = varvault.create(keyring=Keyring, resource=XmlResource(vault_file_new, mode="w"))
 
-        @vault.vaulter(return_keys=(Keyring.string_value, Keyring.int_value, Keyring.list_value))
+        @vault.manual(output=(Keyring.string_value, Keyring.int_value, Keyring.list_value))
         def _set():
             return "valid", 1, [1, 2, 3, 4, 5]
 
@@ -124,7 +124,7 @@ class TestXmlVault:
     def test_read_from_xml_vault(self):
         vault = varvault.create(keyring=Keyring, resource=XmlResource(existing_vault, "r"))
 
-        @vault.vaulter(input_keys=(Keyring.string_value, Keyring.int_value))
+        @vault.manual(input=(Keyring.string_value, Keyring.int_value))
         def _get(string_value=None, int_value=None):
             assert string_value == "valid"
             assert int_value == "1"

--- a/varvault/__init__.py
+++ b/varvault/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.0.3"
+__version__ = "6.0.0"
 
 import os
 import json
@@ -78,7 +78,7 @@ class JsonResource(BaseResource):
         """Returns the file resource object for this handler."""
         return self.file_io
 
-    def create_resource(self) -> None:
+    def create(self) -> None:
         """Creates the resource self.file_io for this handler which we'll use to read and write to."""
         path = self.path
         assert path, "Path is not defined"

--- a/varvault/flags.py
+++ b/varvault/flags.py
@@ -16,15 +16,18 @@ class Flags(enum.Enum):
     return_values_cannot_be_none = enum.auto()
 
     f"""Flag to set if variables may be modified either in the vault itself or for a specific decorated function. 
-        By default, varvault doesn't permit modifications to existing keys as this can cause unintended behavior."""
+    By default, varvault doesn't permit modifications to existing keys as this can cause unintended behavior. 
+    
+    Note that combined with the 'automatic' decorator to subscribe on one or more keys, replacing a key will effectively trigger all subscribed methods again. 
+    """
     permit_modifications = enum.auto()
 
     f"""Flag to set if an input variable may be missing in a vault when it is accessed. In this case, the key will be sent to kwargs but it will be mapped to {None}."""
     input_key_can_be_missing = enum.auto()
 
-    f"""Flag to clean return keys in a vault defined for a decorated function. This can be used during a cleanup stage. 
+    f"""Flag to clean output keys in a vault defined for a decorated function. This can be used during a cleanup stage. 
     Varvault will try to map the key to a default value for the valid type, like for example str(), or list(). If it doesn't work, the key will be mapped to {None}."""
-    clean_return_keys = enum.auto()
+    clean_output_keys = enum.auto()
 
     f"""Flag to enable debug mode for logger output to the console to help you with debugging. By default, varvault will write debug logs to the logfile, but not the console. 
     By setting this, you'll have a much easier time debugging unintended behavior. Using this and 'silent' (see further down) in conjunction will cancel each other out and make logging the default."""
@@ -38,10 +41,10 @@ class Flags(enum.Enum):
     a tuple is multiple return values or a single item meant for a single key as this how Python handles multiple return values"""
     return_tuple_is_single_item = enum.auto()
 
-    f"""Flag to tell varvault that the return keys provided in a MiniVault being returned are split between multiple vaults decorating the same function. 
-    By default, any return values from a decorated function must be able to be mapped to the keys defined as return keys. If two vaults are taking return values separately, 
+    f"""Flag to tell varvault that the output keys provided in a MiniVault being returned are split between multiple vaults decorating the same function. 
+    By default, any return values from a decorated function must be able to be mapped to the keys defined as output keys. If two vaults are taking return values separately, 
     this wouldn't be possible. Usage of this flag REQUIRES that the return value is a MiniVault-object."""
-    split_return_keys = enum.auto()
+    split_output_keys = enum.auto()
 
     f"""Flag to tell varvault to disable logger completely and not log anything to a log-file."""
     disable_logger = enum.auto()
@@ -54,7 +57,7 @@ class Flags(enum.Enum):
 
     f"""Flag to tell varvault when using a vaulter-decorated function and not returning objects for all keys to not fail and just set the keys defined.
      If this is set, the return variables MUST be inside a MiniVault object, otherwise varvault cannot determine what variable belongs to what key."""
-    return_key_can_be_missing = enum.auto()
+    output_key_can_be_missing = enum.auto()
 
     f"""Flag to tell a vaulter-decorated function to not log exceptions. Exceptions can sometimes be expected,
     and sometimes it might be preferable to not log errors using varvault and just log them normally."""
@@ -65,3 +68,15 @@ class Flags(enum.Enum):
     argument the same as the key. This will make tracking where the keys in the Keyring are used harder, but reduces the amount of boilerplate required. Can be defined 
     for the entire vault, or for a specific decorated function only."""
     use_signature_for_input_keys = enum.auto()
+
+    f"""Flag to tell varvault to replace the input key with the output key. This is useful when you want to update the value of a key in the vault.
+    When using the 'automatic' decorator, this can be useful if one function has to create a structure, something else happens using that structure, and then the structure is updated.
+    Using this flag, you can update the structure in the vault by having multiple keys that act as intermediate keys.
+    
+    Example:
+    @vault.automatic(Flags.output_key_replaces_input_key, input=Keyring.intermediate, output=Keyring.final)
+    def func(intermediate=AssignedByVault):
+        intermediate['key'] = 'value'
+        return intermediate
+    """
+    output_key_replaces_input_key = enum.auto()

--- a/varvault/resource.py
+++ b/varvault/resource.py
@@ -142,7 +142,7 @@ class BaseResource(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def create_resource(self):
+    def create(self):
         """Meant to create the resource to store the vault in a database."""
         raise NotImplementedError()
 
@@ -166,7 +166,7 @@ class BaseResource(abc.ABC):
     # Write
     # ================================================================================================================
     def write(self, vault: dict) -> None:
-        f"""Writes the vault to the database by calling the implemented '{self.do_write}' method."""
+        f"""Writes the vault to the database by calling the implemented '{self.do_write}' method. Not meant to be overridden."""
         if not vault:
             # No point writing an empty dict and it's not the job of this method to create the file
             return
@@ -176,7 +176,7 @@ class BaseResource(abc.ABC):
             return
 
         if not self.resource:
-            self.create_resource()
+            self.create()
         try:
             with self.lock:
                 self.do_write(vault)
@@ -203,9 +203,9 @@ class BaseResource(abc.ABC):
     # Read
     # ================================================================================================================
     def read(self) -> Dict:
-        f"""Reads the vault from the database by calling the implemented '{self.do_read}' method."""
+        f"""Reads the vault from the database by calling the implemented '{self.do_read}' method. Not meant to be overridden."""
         if not self.resource:
-            self.create_resource()
+            self.create()
         with self.lock:
             if self.exists():
                 try:

--- a/varvault/subscriber_thread.py
+++ b/varvault/subscriber_thread.py
@@ -1,0 +1,15 @@
+import threading
+
+
+class SubscriberThread(threading.Thread):
+    def __init__(self, subscriber, varvault, *args, **kwargs):
+        super(SubscriberThread, self).__init__(*args, **kwargs)
+        self.subscriber = subscriber
+        self.varvault = varvault
+
+    def run(self):
+        from .vault import VarVault
+        self.varvault.logger.info(f"Starting subscriber thread for {self.subscriber.__name__}...")
+        self.subscriber()
+        self.varvault: VarVault
+        self.varvault.purge_stopped_thread(self)


### PR DESCRIPTION
* Renamed `vaulter` to `manual` since "vaulter" isn't a real word and "manual" describes it better since it's called manually.
* Renamed `input_keys` to `input`, and renamed `return_keys` to `output`.
* Added a big new feature which is a new form of decorator: `automatic`. This decorator works pretty much the same as `manual` does, but will trigger automatically when all input keys exist in the vault and can be viewed as a subscriber. This means that no manual execution of the decorated function is necessary. A subscriber can also run in a thread if you want, meaning you can easily run things in parallel when the conditions are met and just let things happen when they can happen. You can define a conditional for functions defined as `automatic`. A conditional is meant to be a lambda that takes 0 arguments that checks something that evaluates to True. You can use this to, for example, check if a string value in the vault matches something.
* Added a new flag called `output_key_replaces_input_key` and it works as you might expect. A `manual` or `automatic` decorated function with 1 input key and 1 output key with this flag will delete the input key from the vault and insert the output key, meaning the input key will be gone from the vault and effectively replaced by the new key (or at least that's the idea). This can be useful when creating a datastructure that isn't final, but you still want to use `automatic` and trigger on this structure once it's created. With this key you can have intermediate keys before the final one.